### PR TITLE
Podspec for iOS blur

### DIFF
--- a/iOS-blur.podspec
+++ b/iOS-blur.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "iOS-blur"
   s.version      = "0.0.1"
-  s.summary      = "Blur backgrounds using UIViews"
+  s.summary      = "Blur backgrounds using UIViews."
   s.homepage     = "https://github.com/JagCesar/iOS-blur"
   s.license      = 'Custom'
   s.author       = { "César Pinto Castillo" => "cesar@blocket.se" }
   s.source       = { :git => "https://github.com/JagCesar/iOS-blur.git", :commit => "4e223ab6dfc108fa210c6ec5d19373fa24d57de3" }
   s.platform     = :ios, '7.0'
-  s.source_files = 'blur/blur/ARBlurView.*'
+  s.source_files = 'blur/blur/AMBlurView.*'
   s.frameworks = 'CoreImage', 'CoreGraphics'
   s.requires_arc = true
 end


### PR DESCRIPTION
I've added a Podspec so that people can add `pod "iOS-blur", :git => "https://github.com/JagCesar/iOS-blur.git"` to their Podfiles.

I've not added it to the main Specs repo, to give you time to either polish it or to submit yourself.
