### PR TITLE
Able to set blurTintColor instead of the default UIToolBar barTintColor

### DIFF
--- a/blur/blur/AMBlurView.h
+++ b/blur/blur/AMBlurView.h
@@ -9,5 +9,10 @@
 #import <UIKit/UIKit.h>
 
 @interface AMBlurView : UIView
+{
+    UIToolbar *_toolBar;
+}
 
+
+@property (nonatomic, strong) UIColor *blurTintColor;
 @end

--- a/blur/blur/AMBlurView.m
+++ b/blur/blur/AMBlurView.m
@@ -35,8 +35,8 @@
 }
 
 - (void)setup {
-    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:[self bounds]];
-    self.blurLayer = [toolbar layer];
+    _toolBar = [[UIToolbar alloc] initWithFrame:[self bounds]];
+    self.blurLayer = [_toolBar layer];
     
     UIView *blurView = [UIView new];
     [blurView setUserInteractionEnabled:NO];
@@ -49,6 +49,11 @@
     
     [self setBackgroundColor:[UIColor clearColor]];
     [self setClipsToBounds:YES];
+}
+
+- (void) setBlurTintColor:(UIColor *)blurTintColor
+{
+    _toolBar.barTintColor = blurTintColor;
 }
 
 - (void)setFrame:(CGRect)frame {


### PR DESCRIPTION
Otherwise the default `UIToolBar` tint will give the blur a bluish vibe.
