### PR TITLE
Made -initWithFrame: work.

### DIFF
--- a/blur/blur/AMBlurView.m
+++ b/blur/blur/AMBlurView.m
@@ -26,6 +26,14 @@
     return self;
 }
 
+- (id)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self setup];
+    }
+    return self;
+}
+
 - (id)init
 {
     self = [super init];


### PR DESCRIPTION
Previously, `-initWithFrame:` didn't work as `-setup` never got called,
but now it does.
