### PR TITLE
Update the blur layer frame inside layoutSubviews.

### DIFF
--- a/blur/blur/AMBlurView.m
+++ b/blur/blur/AMBlurView.m
@@ -69,4 +69,9 @@
     [self.blurLayer setFrame:[self bounds]];
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self.blurLayer setFrame:[self bounds]];
+}
+
 @end


### PR DESCRIPTION
I had some problems when using auto layout. The `setFrame` seems not to be called when the size of a blur view gets changed. Resizing the layer inside the `layoutSubviews` method fixed my problem.

Changing the blur layer size inside `layoutSubviews` might allow to remove the `setFrame` method completely. But I didn't do any testing and left the `setFrame` as is.
