### PR TITLE
Remove the toolbar background image if one was set

### DIFF
--- a/blur/blur/AMBlurView.m
+++ b/blur/blur/AMBlurView.m
@@ -57,6 +57,8 @@
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[blurView]|" options:0 metrics:nil views:NSDictionaryOfVariableBindings(blurView)]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(-1)-[blurView]-(-1)-|" options:0 metrics:nil views:NSDictionaryOfVariableBindings(blurView)]];
     
+    [self.toolbar setBackgroundImage:[UIImage new] forToolbarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefault];
+    
     [self setBackgroundColor:[UIColor clearColor]];
 }
 


### PR DESCRIPTION
If the toolbar was getting a background image through `UIAppearance` proxy, then we remove it.
